### PR TITLE
Update plugin to use new API

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ async function isTrendErroring(meta) {
     // Only consider the two most recent data points
     const latestDataPoints = result.data.slice(-2);
 
-    return latestDataPoints.some((value) =>
+    return latestDataPoints.every((value) =>
         dataPointInError(value, parseFloat(meta.config.threshold), meta.config.operator)
     )
 }

--- a/index.js
+++ b/index.js
@@ -20,9 +20,27 @@ export async function runEveryMinute(meta) {
 }
 
 async function isTrendErroring(meta) {
-    const { data } = await getTrend(meta)
-    return !data.slice(-2).some((value) =>
-        !dataPointInError(value, parseFloat(meta.config.threshold), meta.config.operator)
+    const insight = await getTrend(meta)
+
+    if(insight.filters.insight !== "TRENDS") {
+        throw "The provided insight is not a trend"
+    }
+
+    const result = insight.result?.[0]
+
+    if(!result) {
+        console.warn("Insight returned no result")
+        return
+    } else if(result.data.length === 0) {
+        console.warn("Insight returned no data")
+        return
+    }
+
+    // Only consider the two most recent data points
+    const latestDataPoints = result.data.slice(-2);
+
+    return latestDataPoints.some((value) =>
+        dataPointInError(value, parseFloat(meta.config.threshold), meta.config.operator)
     )
 }
 
@@ -35,7 +53,14 @@ function dataPointInError(value, threshold, operator) {
 }
 
 async function getTrend(meta) {
-    const response = await fetch(insightsApiUrl(meta.config.posthogTrendUrl), {
+    const insightId = insightIdFromUrl(meta.config.posthogTrendUrl)
+
+    const apiUrl = new URL(
+        `/api/projects/${meta.config.posthogProjectId}/insights?short_id=${insightId}`,
+        meta.config.posthogTrendUrl
+    )
+
+    const response = await fetch(apiUrl, {
         headers: {
             authorization: `Bearer ${meta.config.posthogApiKey}`
         }
@@ -45,10 +70,10 @@ async function getTrend(meta) {
         throw Error(`Error from PostHog API: status=${response.status} response=${await response.text()}`)
     }
 
-    const results = await response.json()
+    const { results } = await response.json()
 
-    console.log('Got PostHog trends response', results)
-    return results.result[0]
+    // console.log('Got PostHog trends results', results)
+    return results[0]
 }
 
 async function triggerPagerduty(meta) {
@@ -92,7 +117,8 @@ async function triggerPagerduty(meta) {
 }
 
 async function resolvePagerduty(incidentKey, meta) {
-    const response = await fetch('https://events.pagerduty.com/v2/enqueue', {
+    // TODO: Should check whether this response was successful
+    await fetch('https://events.pagerduty.com/v2/enqueue', {
         method: 'post',
         headers: {
             'Content-Type': 'application/json',
@@ -108,17 +134,18 @@ async function resolvePagerduty(incidentKey, meta) {
     await meta.cache.set("pagerduty_active_incident", null)
 }
 
-function insightsApiUrl(trendsUrl) {
-    let url = new URL(trendsUrl)
+function insightIdFromUrl(trendsUrl) {
+    const url = new URL(trendsUrl)
 
-    url.searchParams.set('refresh', 'true')
-    if (url.pathname === '/insights') {
-        url = new URL(`${url.origin}/api/insight/trend${url.search}${url.hash}`)
+    if (url.pathname.startsWith('/insights')) {
+        const [_, insightId] = /\/insights\/([a-zA-Z0-9]*)$/.exec(url.pathname)
+
+        if(!insightId) {
+            throw Error(`Not a valid trends URL: ${trendsUrl}`)
+        }
+
+        return insightId
     }
 
-    if (!url.pathname.startsWith('/api/insight/trend')) {
-        throw Error(`Not a valid trends URL: ${trendsUrl}`)
-    }
-
-    return url.href
+    throw Error(`Not a valid trends URL: ${trendsUrl}`)
 }

--- a/plugin.json
+++ b/plugin.json
@@ -71,7 +71,7 @@
             "key": "pagerdutyIncidentSummary",
             "name": "PagerDuty Incident Summary",
             "type": "string",
-            "default": "Posthog query returned no results",
+            "default": "Posthog query returned result outside threshold",
             "required": true
         },
         {

--- a/plugin.json
+++ b/plugin.json
@@ -47,6 +47,15 @@
             "required": true
         },
         {
+            "key": "posthogProjectId",
+            "hint": "The ID of the current project, which can be found in Project settings",
+            "name": "PostHog Project ID",
+            "type": "string",
+            "secret": false,
+            "default": "",
+            "required": true
+        },
+        {
             "markdown": "PagerDuty & incident configuration"
         },
         {


### PR DESCRIPTION
This PR fixes #2 by updating this app to use the new API. In order to achieve this, it was necessary to add a new configuration option for the current project ID which is used to make the request.

The process of the `runEveryMinute` handler is now as follows:
1. Extract the `short_id` from the Insights URL provided in the config
2. Retrieve the result of the Insight using the undocumented `short_id` query parameter
3. Check the value in the same way as before

As of right now the user has to enter the ID for the current project, but it would be nice if this could just be provided by default in the `meta` object. Since it seems as though plugin configs are scoped to specific projects, I would imagine this wouldn't be too difficult.

Also, the documentation for this plugin is in major need of an overhaul, so I'll jump on that sometime this week.

### Notes
Closes #2 
Related Posthog/posthog#10821, PostHog/posthog.com#3800